### PR TITLE
rephrase teaser texts, alternative headings

### DIFF
--- a/_includes/landingPage.html
+++ b/_includes/landingPage.html
@@ -2,33 +2,32 @@
 <div class="lead">
     <div class="logo">{% include icons/logo.html %}</div> 
     <h1 class="headline_1">Test-Editor-Web</h1>
-    <h2 class="headline_2">“UA Tests as they were meant to be”</h2>
-    <p class="phrase_main">It is designed to bridge the gap between domain experts, 
-      testers and developers with a modern application that integrates with container technologies. 
-      It is dedicated to automate the tip of the testing pyramid (acceptance tests) 
-      to enable automated product releases and provide confidence in reliable product operation.
+    <blockquote><h2 class="headline_2">&laquo;User Acceptance Tests as they were meant to be.&raquo;</h2></blockquote>
+    <p class="phrase_main">Designed to bridge the gap between domain experts, 
+      testers, and developers, <em>Test-Editor-Web</em> is a modern application that integrates well with container technologies. 
+      It is dedicated to automate the tip of the testing pyramid&mdash;acceptance testing&mdash;to enable automated product releases and provide confidence in reliable product operation.
     </p>
   </div>
   <hr>
   <div class="row-fluid">
       <div class="span4">
         <h2>Test First</h2>
-        <p> Write test specifications before the actual feature is implemented. 
+        <p> Write test specifications <em>before</em> the actual feature is implemented. 
           Make your tests an integral element of your agile feature development.
           <br><a class="page-link" href="/te_markdown/testfirst/">More ...</a> 
         </p>
       </div>
       <div class="span4">
-        <h2>For Domain Experts</h2>
-        <p> Use a language designed for tests which is designed to be used by domain experts. Define the vocabulary and abstractions of your tests
-            yourself and specify readable, comprehensible and reusable tests.
+        <h2>Test the Domain</h2>
+        <p> Use a language designed to enable <em>domain experts</em> to write tests. Define the vocabulary and abstractions of your tests
+            yourself and specify readable, comprehensible, and reusable tests.
             <br> <a class="page-link" href="/te_markdown/domainexperts/">More ...</a>
         </p>
       </div>
       <div class="span4">
-        <h2>Multiple Test Drivers</h2>
+        <h2>Test Anything</h2>
         <p> Test different technologies, from web applications up to mainframe applications.
-            Use the Test-Editor-Web to test your application, regardless on which technological platform it runs.
+            Use the Test-Editor-Web to test your application, <em>regardless of technology</em>.
             <br><a class="page-link" href="/te_markdown/testdrivers/">More ...</a>
         </p>
       </div>
@@ -36,21 +35,22 @@
     <hr>
     <div class="row-fluid">
         <div class="span4">
-          <h2>Containered Test Execution</h2>
+          <h2>Test Containerized</h2>
           <p> Have automated test executions that run locally exactly as they run in the cloud.
-              Test execution is performed within docker containers that are isolated and complete such that the identical container is used locally as it is used in the cloud.
+              Test execution is performed within <em>Docker containers</em> that are isolated and complete,
+              such that the identical container is used locally as it is used in the cloud.
             <br><a class="page-link" href="/te_markdown/testexec/">More ...</a> 
           </p>
         </div>
         <div class="span4">
-          <h2>Web UI</h2>
-          <p> Make use of a feature rich editor without the need of local installations. Specify and run your tests without the need of a fat client.
+          <h2>Test in the Web</h2>
+          <p> Make use of a feature-rich editor that <em>lives in the browser</em>. Specify and run your tests without the need for locally installed fat clients.
               <br> <a class="page-link" href="/te_markdown/webui/">More ...</a>
           </p>
         </div>
         <div class="span4">
-          <h2>Seamlessly integrate into your CI</h2>
-          <p> Integrate your tests into existing CI pipelines without any hassle.
+          <h2>Test Continuously</h2>
+          <p>Seamlessly integrate your tests into existing CI pipelines without any hassle.
               <br><a class="page-link" href="/te_markdown/ci/">More ...</a>
           </p>
         </div>


### PR DESCRIPTION
Consider this a draft to illustrate more consistent headers for the six key aspects. Its a work-in-progress, because I think its now so over-stylized that it feels factitious. So, the idea is that every heading should be, for example, a verbal phrase; not every heading _has_ to start with "Test"… :wink: 