### PR TITLE
line up buttons on landing page

### DIFF
--- a/_includes/landingPage.html
+++ b/_includes/landingPage.html
@@ -15,65 +15,74 @@
   </div>
   <hr>
   <div class="row-fluid">
-      <div class="span4">
-        <h2>Test First</h2>
-        <p> Write test specifications <em>before</em> the actual feature is implemented. 
-          Make your tests an integral element of your agile feature development.
-          <br>
-          <div class="get-button">
-            <a class="web-button-grey" href="/te_markdown/testfirst/">Learn More ...</a> 
-        </div>    
-        </p>
-      </div>
-      <div class="span4">
-        <h2>Test <em>Your</em> Domain</h2>
-        <p> Use a language designed to enable <em>domain experts</em> to write tests. Define the vocabulary and abstractions of your tests
-            yourself and specify readable, comprehensible, and reusable tests.
-            <br> 
-            <div class="get-button">
-              <a class="web-button-grey" href="/te_markdown/domainexperts/">Learn More ...</a>
-            </div>  
-        </p>
-      </div>
-      <div class="span4">
-        <h2>Test <em>Your</em> Application</h2>
-        <p> Test different technologies, from web applications up to mainframe applications.
-            Use the Test-Editor-Web to test your application, <em>regardless of technology</em>.
-            <br>
-            <div class="get-button">
-                <a class="web-button-grey" href="/te_markdown/testdrivers/">Learn More ...</a>
-            </div>
-        </p>
+    <div class="span4">
+      <h2>Test First</h2>
+      <p> Write test specifications <em>before</em> the actual feature is implemented. 
+        Make your tests an integral element of your agile feature development.
+      </p>
+    </div>
+    <div class="span4">
+      <h2>Test <em>Your</em> Domain</h2>
+      <p> Use a language designed to enable <em>domain experts</em> to write tests. Define the vocabulary and abstractions of your tests
+          yourself and specify readable, comprehensible, and reusable tests.
+      </p>
+    </div>
+    <div class="span4">
+      <h2>Test <em>Your</em> Application</h2>
+      <p> Test different technologies, from web applications up to mainframe applications.
+          Use the Test-Editor-Web to test your application, <em>regardless of technology</em>.
+      </p>
+    </div>
+  </div>
+  <div class="row-fluid">
+    <div class="span4">
+      <div class="get-button">
+          <a class="web-button-grey" href="/te_markdown/testfirst/">Learn More ...</a> 
       </div>
     </div>
+    <div class="span4">
+        <div class="get-button">
+            <a class="web-button-grey" href="/te_markdown/domainexperts/">Learn More ...</a>
+          </div>  
+    </div>
+    <div class="span4">
+        <div class="get-button">
+              <a class="web-button-grey" href="/te_markdown/testdrivers/">Learn More ...</a>
+          </div>
+    </div>
+  </div>
     <hr>
     <div class="row-fluid">
         <div class="span4">
           <h2>Test Containerized</h2>
-          <p> Have automated test executions that run locally exactly as they run in the cloud.
-          <br>
-            <div class="get-button">
-                <a class="web-button-grey" href="/te_markdown/testexec/">Learn More ...</a> 
-            </div>
-          </p>
+          <p>Have automated test executions that run locally exactly as they run in the cloud.</p>
         </div>
         <div class="span4">
           <h2>Test in Your Browser</h2>
-          <p> Make use of a feature-rich editor that <em>lives in the browser</em>. Specify and run your tests without the need for locally installed fat clients.
-              <br>
-              <div class="get-button">
-                <a class="web-button-grey" href="/te_markdown/webui/">Learn More ...</a>
-              </div>
+          <p> Make use of a feature-rich editor that <em>lives in the browser</em>.
+              Specify and run your tests without the need for locally installed fat clients.
           </p>
         </div>
         <div class="span4">
           <h2>Test Continuously</h2>
-          <p>Seamlessly integrate your tests into existing CI pipelines without any hassle.
-              <br>
-              <div class="get-button">
-                <a class="web-button-grey" href="/te_markdown/ci/">Learn More ...</a>
-              </div>
-          </p>
+          <p>Seamlessly integrate your tests into existing CI pipelines without any hassle.</p>
         </div>
     </div>
+    <div class="row-fluid">
+      <div class="span4">
+        <div class="get-button">
+          <a class="web-button-grey" href="/te_markdown/testexec/">Learn More ...</a> 
+        </div>
+      </div>
+      <div class="span4">
+        <div class="get-button">
+          <a class="web-button-grey" href="/te_markdown/webui/">Learn More ...</a>
+        </div>
+      </div>
+      <div class="span4">
+        <div class="get-button">
+          <a class="web-button-grey" href="/te_markdown/ci/">Learn More ...</a>
+        </div>
+      </div>
+  </div>
     <hr>


### PR DESCRIPTION
Consider this merely an option for our landing page option, rather than a pull "request". Prompted by the  feedback we got, I just wanted to try out if it would be easy to neatly line up the buttons in a row. Turns out, it is:

![selection_065](https://user-images.githubusercontent.com/2879473/49088200-07b34380-f259-11e8-8cfd-cda4ec564621.png)